### PR TITLE
Use defaults and remove old test pages

### DIFF
--- a/.stackbit/models/Page.yaml
+++ b/.stackbit/models/Page.yaml
@@ -1,4 +1,5 @@
 name: Page
+layout: Page
 hideContent: true
 fields:
   - type: string

--- a/content/pages/example.md
+++ b/content/pages/example.md
@@ -1,5 +1,0 @@
----
-type: Page
-title: Example Page
-body: "Elit eu sint sint elit commodo aute tempor ad aute in id."
----

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -1,5 +1,5 @@
 ---
-type: Page
+layout: Page
 title: Stackbit Next.js Starter
 sections:
   - heading: Welcome to Stackbit!

--- a/content/pages/nested/example.md
+++ b/content/pages/nested/example.md
@@ -1,5 +1,0 @@
----
-type: Page
-title: Nested Example Page
-body: "Minim consectetur aliquip Lorem ut aute ut occaecat eu."
----

--- a/content/pages/nested/index.md
+++ b/content/pages/nested/index.md
@@ -1,5 +1,0 @@
----
-type: Page
-title: Nested Index Page
-body: "Ad nulla elit proident ipsum et veniam tempor deserunt proident do commodo sunt."
----

--- a/pages/[[...slug]].js
+++ b/pages/[[...slug]].js
@@ -5,10 +5,10 @@ import { DynamicComponent } from "../components/DynamicComponent";
 import { Footer } from "../components/Footer";
 
 import { pageUrlPath } from "../utils/page-utils";
-import { documentsByType, dataObjectByType } from "../utils/sourcebit-utils";
+import { pagesByLayout, dataByType } from "../utils/sourcebit-utils";
 
-const allPages = documentsByType("Page");
-const siteConfig = dataObjectByType("SiteConfig");
+const allPages = pagesByLayout("Page");
+const siteConfig = dataByType("SiteConfig");
 
 const FlexiblePage = ({ page, footer }) => {
   return (

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -5,7 +5,6 @@ cmsName: git
 publishDir: .next
 dataDir: content/data
 pagesDir: content/pages
-pageLayoutKey: type
 assets:
   referenceType: static
   staticDir: public
@@ -16,3 +15,9 @@ contentModels:
     isPage: true
     urlPath: "/{slug}"
     newFilePath: "{slug}.md"
+  BlogPage:
+    isPage: true
+    singleInstance: true
+    urlPath: "/blog"
+    file: "blog/index.md"
+    newFilePath: "blog/index.md"

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -15,9 +15,3 @@ contentModels:
     isPage: true
     urlPath: "/{slug}"
     newFilePath: "{slug}.md"
-  BlogPage:
-    isPage: true
-    singleInstance: true
-    urlPath: "/blog"
-    file: "blog/index.md"
-    newFilePath: "blog/index.md"

--- a/utils/sourcebit-utils.js
+++ b/utils/sourcebit-utils.js
@@ -3,14 +3,14 @@ import dataCache from "../.sourcebit-nextjs-cache.json";
 export const allDocuments = dataCache.objects;
 
 /**
- * Extract objects from the data cache by matching the "type" property in
+ * Extract objects from the data cache by matching the "layout" property in
  * frontmatter.
  *
  * @param {string} type Name of the model
  * @returns {array} Sourcebit data objects
  */
-export function documentsByType(type) {
-  return allDocuments.filter((doc) => doc?.frontmatter?.type === type);
+export function pagesByLayout(layout) {
+  return allDocuments.filter((doc) => doc?.frontmatter?.layout === layout);
 }
 
 /**
@@ -20,6 +20,6 @@ export function documentsByType(type) {
  * @param {string} type Name of the model
  * @returns {object} First matching object
  */
-export function dataObjectByType(type) {
+export function dataByType(type) {
   return allDocuments.find((obj) => obj?.type === type);
 }


### PR DESCRIPTION
Pages now use the default `layout` property instead of `type`. 

Also removes the extra pages that were in there to test that the routing was working properly.

---

Fixes #2 
Fixes #3

