### PR TITLE
fix: handle string slug values

### DIFF
--- a/pages/[[...slug]].js
+++ b/pages/[[...slug]].js
@@ -40,7 +40,10 @@ const FlexiblePage = ({ page, footer }) => {
 export default FlexiblePage;
 
 export const getStaticProps = async ({ params }) => {
-  const pagePath = "/" + (params?.slug || []).join("/");
+  const pagePath =
+    typeof params?.slug === "string"
+      ? params?.slug
+      : "/" + (params?.slug || []).join("/");
   const page = allPages.find((page) => pageUrlPath(page) === pagePath);
   return { props: { page, footer: siteConfig.footer } };
 };


### PR DESCRIPTION
[ParsedUrlQuery](https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules__types_node_querystring_d_._querystring_.parsedurlquery.html) values may be of type `string` | `string[]`, depending on the  circumstance. This update handles both as valid inputs.


Thoughts?