### PR TITLE
updated dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
             "dependencies": {
                 "front-matter": "^4.0.2",
                 "glob": "^8.0.3",
-                "markdown-to-jsx": "^7.1.7",
+                "markdown-to-jsx": "^7.2.0",
                 "next": "^13.4.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
             },
             "devDependencies": {
-                "@stackbit/cms-git": "^0.3.2",
-                "@stackbit/types": "^0.6.2",
+                "@stackbit/cms-git": "^0.3.3",
+                "@stackbit/types": "^0.7.0",
                 "eslint": "^8.28.0",
                 "eslint-config-next": "^13.0.4"
             }
@@ -831,17 +831,17 @@
             "dev": true
         },
         "node_modules/@stackbit/cms-core": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.5.2.tgz",
-            "integrity": "sha512-nQHpWzw+jwNPY87RTtynZ1lrJw1AKn4QQEccI0m0M6vRhOedAnHyqlW63T8CX/6eazwBBaAM3v7jiBtFB4//3Q==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.6.0.tgz",
+            "integrity": "sha512-BFx11EPxff/3D7bpNNRCkbVC9ksmRyoI4rVhRrQ/X62aj38J8DovTa3xMi4QG/PElt52wV4Vsjn8e8BSuH2MSQ==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.11.5",
                 "@babel/traverse": "^7.11.5",
                 "@iarna/toml": "^2.2.3",
-                "@stackbit/sdk": "0.5.2",
-                "@stackbit/types": "0.6.2",
-                "@stackbit/utils": "0.2.29",
+                "@stackbit/sdk": "0.5.3",
+                "@stackbit/types": "0.7.0",
+                "@stackbit/utils": "0.2.30",
                 "chalk": "^4.0.1",
                 "esm": "^3.2.25",
                 "fs-extra": "^8.1.0",
@@ -932,16 +932,16 @@
             }
         },
         "node_modules/@stackbit/cms-git": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/cms-git/-/cms-git-0.3.2.tgz",
-            "integrity": "sha512-NO7o2lkHAdTJZ8+fEURAWoESB/ZxLNWILwU62iJGK4xOa9l+64hV86/1s6zGpgddJyGdnmt/B4Eof7QzndZrWA==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@stackbit/cms-git/-/cms-git-0.3.3.tgz",
+            "integrity": "sha512-/O2aoCYs8xpU/OrGJPryaASOIqH3BvsL1eESvlR1LBnznW+PC25sLoGsXYB600V+t3jY0uC/z9Yhojw6VdFpMA==",
             "dev": true,
             "dependencies": {
                 "@stackbit/artisanal-names": "^1.0.1",
-                "@stackbit/cms-core": "0.5.2",
-                "@stackbit/sdk": "0.5.2",
-                "@stackbit/types": "0.6.2",
-                "@stackbit/utils": "0.2.29",
+                "@stackbit/cms-core": "0.6.0",
+                "@stackbit/sdk": "0.5.3",
+                "@stackbit/types": "0.7.0",
+                "@stackbit/utils": "0.2.30",
                 "axios": "^0.24.0",
                 "fs-extra": "^11.1.0",
                 "git-url-parse": "^13.1.0",
@@ -951,14 +951,14 @@
             }
         },
         "node_modules/@stackbit/sdk": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.2.tgz",
-            "integrity": "sha512-pNn8gDFw5t3Cw05Q5yo5lQ7vCCXlbG8o13cyihJqTCLflrIf+Ne78MVIfoMaLvb5RHMz9CJ3W6163v+ATdCR3g==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.3.tgz",
+            "integrity": "sha512-GfGfUjzRUjZEgDfWdB7hSWGKCdZLNHyRhkdOIu1VtSkJZuEVQ5S+eA7MxyttPLVhytzSiHGVOL/KHRS0bQ1LdQ==",
             "dev": true,
             "dependencies": {
                 "@octokit/rest": "^18.3.5",
-                "@stackbit/types": "0.6.2",
-                "@stackbit/utils": "0.2.29",
+                "@stackbit/types": "0.7.0",
+                "@stackbit/utils": "0.2.30",
                 "acorn": "^8.2.4",
                 "chokidar": "^3.5.3",
                 "esbuild": "^0.14.42",
@@ -987,15 +987,15 @@
             }
         },
         "node_modules/@stackbit/types": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.6.2.tgz",
-            "integrity": "sha512-wA0B2Sfygj1YL5R0exuzzn3nB2FouxPDoxB0ImSy7TzsCO7JO1eXtTsDDAf81yRDlsGo2rIHIb5hfwQK4Jg7Kg==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.7.0.tgz",
+            "integrity": "sha512-66ggCpiA32mxKtxOzBhyduN4Ea27+KsbOuKp6n9wZjQ7Z7MvTo3NO5FE4qC3nZBiZjaTafSGLxxi2bFsN0bTxQ==",
             "dev": true
         },
         "node_modules/@stackbit/utils": {
-            "version": "0.2.29",
-            "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.29.tgz",
-            "integrity": "sha512-cmbbtNkfbCVcA+pye9LWPCzKKueTHgHnERzaBef2cxpfbESjFSt2HBOUTyAEug1QEyV9FMjYPVBRX8HxwVzMdw==",
+            "version": "0.2.30",
+            "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.30.tgz",
+            "integrity": "sha512-lb/GuRbiYgZXzAAvYwwGnSn8QBfWTOzVUugDVuoKmU4/Rb8Tt1N9sCPEBhRy4Yh7y8liB1RMXVYg4x9LB1Mgaw==",
             "dev": true,
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
@@ -3534,9 +3534,9 @@
             }
         },
         "node_modules/markdown-to-jsx": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
-            "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz",
+            "integrity": "sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==",
             "engines": {
                 "node": ">= 10"
             },
@@ -5370,17 +5370,17 @@
             "dev": true
         },
         "@stackbit/cms-core": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.5.2.tgz",
-            "integrity": "sha512-nQHpWzw+jwNPY87RTtynZ1lrJw1AKn4QQEccI0m0M6vRhOedAnHyqlW63T8CX/6eazwBBaAM3v7jiBtFB4//3Q==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@stackbit/cms-core/-/cms-core-0.6.0.tgz",
+            "integrity": "sha512-BFx11EPxff/3D7bpNNRCkbVC9ksmRyoI4rVhRrQ/X62aj38J8DovTa3xMi4QG/PElt52wV4Vsjn8e8BSuH2MSQ==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.11.5",
                 "@babel/traverse": "^7.11.5",
                 "@iarna/toml": "^2.2.3",
-                "@stackbit/sdk": "0.5.2",
-                "@stackbit/types": "0.6.2",
-                "@stackbit/utils": "0.2.29",
+                "@stackbit/sdk": "0.5.3",
+                "@stackbit/types": "0.7.0",
+                "@stackbit/utils": "0.2.30",
                 "chalk": "^4.0.1",
                 "esm": "^3.2.25",
                 "fs-extra": "^8.1.0",
@@ -5458,16 +5458,16 @@
             }
         },
         "@stackbit/cms-git": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/cms-git/-/cms-git-0.3.2.tgz",
-            "integrity": "sha512-NO7o2lkHAdTJZ8+fEURAWoESB/ZxLNWILwU62iJGK4xOa9l+64hV86/1s6zGpgddJyGdnmt/B4Eof7QzndZrWA==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@stackbit/cms-git/-/cms-git-0.3.3.tgz",
+            "integrity": "sha512-/O2aoCYs8xpU/OrGJPryaASOIqH3BvsL1eESvlR1LBnznW+PC25sLoGsXYB600V+t3jY0uC/z9Yhojw6VdFpMA==",
             "dev": true,
             "requires": {
                 "@stackbit/artisanal-names": "^1.0.1",
-                "@stackbit/cms-core": "0.5.2",
-                "@stackbit/sdk": "0.5.2",
-                "@stackbit/types": "0.6.2",
-                "@stackbit/utils": "0.2.29",
+                "@stackbit/cms-core": "0.6.0",
+                "@stackbit/sdk": "0.5.3",
+                "@stackbit/types": "0.7.0",
+                "@stackbit/utils": "0.2.30",
                 "axios": "^0.24.0",
                 "fs-extra": "^11.1.0",
                 "git-url-parse": "^13.1.0",
@@ -5477,14 +5477,14 @@
             }
         },
         "@stackbit/sdk": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.2.tgz",
-            "integrity": "sha512-pNn8gDFw5t3Cw05Q5yo5lQ7vCCXlbG8o13cyihJqTCLflrIf+Ne78MVIfoMaLvb5RHMz9CJ3W6163v+ATdCR3g==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@stackbit/sdk/-/sdk-0.5.3.tgz",
+            "integrity": "sha512-GfGfUjzRUjZEgDfWdB7hSWGKCdZLNHyRhkdOIu1VtSkJZuEVQ5S+eA7MxyttPLVhytzSiHGVOL/KHRS0bQ1LdQ==",
             "dev": true,
             "requires": {
                 "@octokit/rest": "^18.3.5",
-                "@stackbit/types": "0.6.2",
-                "@stackbit/utils": "0.2.29",
+                "@stackbit/types": "0.7.0",
+                "@stackbit/utils": "0.2.30",
                 "acorn": "^8.2.4",
                 "chokidar": "^3.5.3",
                 "esbuild": "^0.14.42",
@@ -5512,15 +5512,15 @@
             }
         },
         "@stackbit/types": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.6.2.tgz",
-            "integrity": "sha512-wA0B2Sfygj1YL5R0exuzzn3nB2FouxPDoxB0ImSy7TzsCO7JO1eXtTsDDAf81yRDlsGo2rIHIb5hfwQK4Jg7Kg==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@stackbit/types/-/types-0.7.0.tgz",
+            "integrity": "sha512-66ggCpiA32mxKtxOzBhyduN4Ea27+KsbOuKp6n9wZjQ7Z7MvTo3NO5FE4qC3nZBiZjaTafSGLxxi2bFsN0bTxQ==",
             "dev": true
         },
         "@stackbit/utils": {
-            "version": "0.2.29",
-            "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.29.tgz",
-            "integrity": "sha512-cmbbtNkfbCVcA+pye9LWPCzKKueTHgHnERzaBef2cxpfbESjFSt2HBOUTyAEug1QEyV9FMjYPVBRX8HxwVzMdw==",
+            "version": "0.2.30",
+            "resolved": "https://registry.npmjs.org/@stackbit/utils/-/utils-0.2.30.tgz",
+            "integrity": "sha512-lb/GuRbiYgZXzAAvYwwGnSn8QBfWTOzVUugDVuoKmU4/Rb8Tt1N9sCPEBhRy4Yh7y8liB1RMXVYg4x9LB1Mgaw==",
             "dev": true,
             "requires": {
                 "@iarna/toml": "^2.2.5",
@@ -7291,9 +7291,9 @@
             }
         },
         "markdown-to-jsx": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
-            "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz",
+            "integrity": "sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==",
             "requires": {}
         },
         "merge2": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "dependencies": {
         "front-matter": "^4.0.2",
         "glob": "^8.0.3",
-        "markdown-to-jsx": "^7.1.7",
+        "markdown-to-jsx": "^7.2.0",
         "next": "^13.4.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "@stackbit/cms-git": "^0.3.2",
-        "@stackbit/types": "^0.6.2",
+        "@stackbit/cms-git": "^0.3.3",
+        "@stackbit/types": "^0.7.0",
         "eslint": "^8.28.0",
         "eslint-config-next": "^13.0.4"
     }


### PR DESCRIPTION
Updated:
- `markdown-to-jsx` to v7.2.0
- `@stackbit/cms-git` to v0.3.3
- `@stackbit/types` to v0.7.0